### PR TITLE
Fix member payment import

### DIFF
--- a/members/models.py
+++ b/members/models.py
@@ -248,7 +248,7 @@ class PaymentManager(models.Manager):
         import csv
 
         f = open(filename, 'r')
-        r = csv.reader(f, delimiter=";")
+        r = csv.reader(f, delimiter=b";")
 
         for line in r:
             if len(line) < 2:

--- a/members/models.py
+++ b/members/models.py
@@ -428,7 +428,7 @@ class Payment(models.Model):
     objects = PaymentManager()
 
     def __str__(self):
-        return ', '.join([self.date, self.amount, self.user.username, self.method.name])
+        return ', '.join([str(self.date), str(self.amount), str(self.user.username), str(self.method.name)])
 
     class Meta:
         ordering = ['date']


### PR DESCRIPTION
Hi, I had two issues when trying to import a member collection csv.

1. The csv wasn't parsed because the delimiter was chosen as an unicode instead of bytecode literal resulting in the following error message: ```"delimiter" must be an 1-character string"```
2. It seems python can (now?) only join strings, so the data has to be converted into a string before the join operation.

I could successfully import and display my import. I have no idea about django, nor python - so I guess you could do the string operation in a different way.