### PR TITLE
remove python2ism from payment tests

### DIFF
--- a/members/tests/test_import_payments.py
+++ b/members/tests/test_import_payments.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 import shutil
-from StringIO import StringIO
+from io import StringIO
 
 from django.test import TestCase
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/loader.py", line 312, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.4/unittest/loader.py", line 290, in _get_module_from_name
    __import__(name)
  File "/vagrant/members/tests/test_import_payments.py", line 5, in <module>
    from StringIO import StringIO
ImportError: No module named 'StringIO'
```