### PR TITLE
make corona warning smaller, add open day announcement

### DIFF
--- a/static/stylesheets/layout.css
+++ b/static/stylesheets/layout.css
@@ -127,9 +127,8 @@
 	padding-bottom: 1em;
 }
 
-#announcement{
+.announcement{
 	float:left;
-	border-left: 4px solid red;
 	margin-bottom: 2em;
 	padding-bottom: 1em;
 	padding: 1.5em 1em 1.5em 1.5em;
@@ -137,12 +136,20 @@
 	font-weight: bold;
 }
 
-#announcement a{
+.announcement.red{
+	border-left: 4px solid red;
+}
+
+.announcement.green{
+	border-left: 4px solid green;
+}
+
+.announcement a{
 	font-weight: bold;
 	font-size: 130%;
 	}
 
-#announcement small{
+.announcement small{
 	font-weight: bold;
 	font-size: 80%;
 	}

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,23 +41,15 @@
 		<span id='extrasmall'><a href="http://florianhufsky.soup.io" target="_blank">condolence blog</a></span><br />
 		<small>Vienna, 17.12.2009</small>
 	</div>-->
-  <div id="announcement">
+  <div class="announcement green">
+    Willst du das Metalab besuchen? Komm Abends vorbei oder besuche uns am Open Day (Kalender links)!<br />
+    <hr>
+    Want to visit the Metalab? Come by in the evening or visit us on Open Day (calendar on the left)!<br />
+  </div>
+  <div class="announcement red">
     Der aktuelle Stand unserer Corona-Regeln ist hier verfügbar: <span id='extrasmall'><a href="/wiki/COVID-19" target="_blank">COVID-19 Infopage im Metalab Wiki</a></span><br />
-    Wenn ihr Fragen habt, könnt ihr euch gerne unter core [et] metalab {dot} at melden!
-    <br /><br />
-    Achtet auf euch und bleibt gesund,<br />
-    Euer Metalab Core Team<br />
-    <br />
-    <small>Wien, 29.09.2020</small><br />
-    _______________________________________________________________________________<br />
-    <br />
-    <br />
+    <hr>
     Latest Updates about Corona are available here: <span id='extrasmall'><a href="/wiki/COVID-19/en" target="_blank">COVID-19 Infopage in the Metalab Wiki</a></span><br />
-    For questions you can contact us via core [et] metalab {dot} at !
-    <br /><br />
-    Stay safe,<br />
-    The Metalab Core Team<br /><br />
-    <small>Vienna, 29.09.2020</small>
   </div>
 	<div id="project_list">
 		<h1><a href="/project/" title="Projekte">Projekte</a></h1>


### PR DESCRIPTION
Open day works very well for attracting new people, so advertise it more. Also make the corona warning smaller, because everyone already knows by now that corona is in the house.