### PR TITLE
Make membership debt calc faster

### DIFF
--- a/members/management/commands/generate_many_members.py
+++ b/members/management/commands/generate_many_members.py
@@ -1,0 +1,59 @@
+import datetime
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from dateutil.relativedelta import relativedelta
+from ...models import PaymentMethod, User
+from ...models import ContactInfo
+from ...models import KindOfMembership
+from ...models import Payment
+from ...models import MembershipPeriod
+
+
+class Command(BaseCommand):
+    help = 'Generate a lot of members for testing'
+    args = "./manage.py import_payment absolute_filepath date(yyyy-mm-dd)"
+
+
+    def add_arguments(self, parser):
+        parser.add_argument('--number-of-members', type=int, required=True)
+        parser.add_argument('--memberships-per-member', type=int, required=True)
+
+    @transaction.atomic
+    def handle(self, number_of_members, memberships_per_member, *args, **options):
+        for member_num in range(number_of_members):
+            user = User.objects.filter(username=f"member{member_num}").delete()
+            user = User.objects.create(username=f"member{member_num}")
+
+            info = ContactInfo.objects.create(
+                user=user,
+            )
+
+            start_date = datetime.datetime(1960, 1, 1)
+
+            kind_of_membership = KindOfMembership.objects.first()
+            fee = kind_of_membership.membershipfee_set.first()
+            fee.start = start_date
+            fee.save()
+
+            for _ in range(memberships_per_member):
+                new_start_date = start_date + relativedelta(months=1)
+                MembershipPeriod.objects.create(
+                    begin=start_date,
+                    end=new_start_date,
+                    user=user,
+                    kind_of_membership=kind_of_membership,
+                )
+                Payment.objects.create(
+                    date=start_date + relativedelta(days=3),
+                    user=user,
+                    amount=10,
+                    method=PaymentMethod.objects.first(),
+                )
+                start_date = new_start_date
+
+            MembershipPeriod.objects.create(
+                begin=new_start_date,
+                user=user,
+                kind_of_membership=kind_of_membership,
+            )

--- a/members/models.py
+++ b/members/models.py
@@ -77,8 +77,6 @@ class ContactInfo(models.Model):
     remark = models.TextField(null=True, blank=True)
 
     def get_debts(self):
-        # FIXME: this is broken because it assumes that a membership period
-        #       has a constant fee
         arrears = 0
         mp_list = MembershipPeriod.objects.filter(user=self.user)
         for mp in mp_list:

--- a/members/models.py
+++ b/members/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from decimal import Decimal
+from django.db.models import Sum
 
 from django.db import models
 from django.db.models import Q
@@ -79,13 +80,17 @@ class ContactInfo(models.Model):
     def get_debts(self):
         arrears = 0
         mp_list = MembershipPeriod.objects.filter(user=self.user)
+        fees = list(MembershipFee.objects.all())
+
+        def get_fee(kind_of_membership, month):
+            for fee in fees:
+                if fee.kind_of_membership == kind_of_membership and fee.start <= month and (fee.end is None or fee.end >= month):
+                    return fee
+            raise Exception(f"could not find a membership fee for month {month} and kind of membership {kind_of_membership}")
+
         for mp in mp_list:
             for month in mp.get_months():
-                fee = MembershipFee.objects.get(
-                    Q(kind_of_membership=mp.kind_of_membership),
-                    Q(start__lte=month),
-                    Q(end__isnull=True) | Q(end__gte=month)
-                )
+                fee = get_fee(mp.kind_of_membership, month)
                 if fee.amount > 0:
                     arrears += fee.amount
         return arrears - self.get_all_payments()
@@ -109,11 +114,7 @@ class ContactInfo(models.Model):
             return fee.amount
 
     def get_all_payments(self):
-        payments = 0
-        p_list = Payment.objects.filter(user=self.user)
-        for p in p_list:
-            payments += p.amount
-        return payments
+        return Payment.objects.filter(user=self.user).aggregate(Sum('amount'))['amount__sum']
 
     def get_date_of_entry(self):
         # FIXME: the order here is wrong, didn't change it since i don't have time to check all implications


### PR DESCRIPTION
MOS Hackathon PR 1

Calculating the member debt currently involves hitting the database many times. This reduces the number of queries drastically.