### PR TITLE
reduce load of ical view

### DIFF
--- a/cal/models.py
+++ b/cal/models.py
@@ -46,7 +46,7 @@ class FutureEventFixedNumberManager(EventManager):
         num = getattr(settings, 'HOS_HOME_EVENT_NUM', 5)
         return self.get_n(num)
 
-    def get_n(self, num):
+    def get_n(self, num, past_duration=datetime.timedelta(hours=5)):
         all = super(FutureEventFixedNumberManager, self).get_queryset().order_by('startDate')
 
         if num == 0:
@@ -55,8 +55,8 @@ class FutureEventFixedNumberManager(EventManager):
         future = all.filter(
             (Q(endDate__gte=datetime.datetime.now())) |
             (Q(endDate__isnull=True) &
-             Q(startDate__gte=datetime.datetime.now() - datetime.timedelta(hours=5)))
-        ).order_by('startDate')  # event visible 5 hours after it started
+             Q(startDate__gte=datetime.datetime.now() - past_duration))
+        ).order_by('startDate')  # event visible X hours/days/weeks/... after it started
 
         if(future.count() < num):
             if(all.count() - num >= 0):

--- a/cal/urls.py
+++ b/cal/urls.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+import datetime
 
 from django.urls import path, re_path
 from django.views.generic.dates import YearArchiveView
 from django.views.generic.detail import DetailView
+from functools import partial
 
 from .models import Event, Location, Category
 import cal.views
@@ -86,7 +88,13 @@ urlpatterns = [
     ),
     path(
         'export/ical/',
-        cal.views.complete_ical,
+        partial(cal.views.complete_ical, num=100, past_duration=datetime.timedelta(days=7)),
+        {},
+        'small_ical',
+    ),
+    path(
+        'export/ical_full/',
+        partial(cal.views.complete_ical, num=0, past_duration=None),
         {},
         'full_ical',
     ),

--- a/cal/views.py
+++ b/cal/views.py
@@ -202,10 +202,10 @@ def event_icalendar(request, object_id):
     return response
 
 
-def complete_ical(request, number=0):
-    events = Event.future.get_n(int(number) if number != '' else 0)
+def complete_ical(request, num, past_duration):
+    events = Event.future.get_n(num, past_duration)
 
-    if not number:
+    if not num:
         events = events.reverse()
 
     calendar = create_calendar([x.get_icalendar_event() for x in events])

--- a/templates/cal/eventinfo_nf.inc
+++ b/templates/cal/eventinfo_nf.inc
@@ -20,7 +20,7 @@
 
   {%else%}
     {% if user.is_authenticated and not edit_disabled %}
-    <p><a href="{% url 'full_ical' %}">Download ALL events in ical format</a></p>
+    <p><a href="{% url 'small_ical' %}">Download current events in ical format</a></p>
     <p>
       <a href='#' class="btn" onclick="toggleView('calendar', '', 1); return false;">
         Create new event

--- a/templates/cal/eventinfo_nf.inc
+++ b/templates/cal/eventinfo_nf.inc
@@ -19,8 +19,8 @@
   </p>
 
   {%else%}
-    {% if user.is_authenticated and not edit_disabled %}
     <p><a href="{% url 'small_ical' %}">Download current events in ical format</a></p>
+    {% if user.is_authenticated and not edit_disabled %}
     <p>
       <a href='#' class="btn" onclick="toggleView('calendar', '', 1); return false;">
         Create new event


### PR DESCRIPTION
Instead of exporting all events since the start of time when users ask for ical, show just the future ones & 7 days in the last. The full ical is still available as `export/ical_full/`. Additionally, the ical feed is now publicly linked since it's not expensive to use anymore.