### PR TITLE
fix(cal): fix URL regex to accept spaces in rooms/categories

### DIFF
--- a/cal/urls.py
+++ b/cal/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         cal.views.monthly,
     ),
     re_path(
-        r'^special/(?P<typ>\w+)/(?P<name>\w+)/$',
+        r'^special/(?P<typ>\w+)/(?P<name>[\w ]+)/$',
         cal.views.display_special_events,
     ),
     re_path(


### PR DESCRIPTION
Fixes Spaces in URL for the categories/rooms.
e.g. https://metalab.at/calendar/special/Location/jour%20fixe/
or https://metalab.at/calendar/special/Location/heavy%20machinery/