### PR TITLE
select public upcoming events in a way that also shows ongoing multi-day appointments

### DIFF
--- a/cal/views.py
+++ b/cal/views.py
@@ -224,7 +224,7 @@ class SpecialListView(ListView):
 
 def public_upcoming(request):
     events = Event.objects.not_deleted().advertise().filter(
-        startDate__gt=timezone.now().date(),
+        endDate__gte=timezone.now().date(),
     ).order_by("startDate", "pk")[:5]
 
     data = []


### PR DESCRIPTION
instead of filtering by start date, we need to filter by end date so we don't exclude events that have started before today but could still be ongoing.