### PR TITLE
Show iCalendar URL for non-logged-in users

### DIFF
--- a/templates/cal/eventinfo_nf.inc
+++ b/templates/cal/eventinfo_nf.inc
@@ -14,7 +14,9 @@
       <a href='#' class="hoverHidden" onclick="toggleView('calendar', '{{event.id}}', 1); return false;">
         Edit
       </a>
+    {%endif %}
       <a class="hoverHidden" href="{{event.get_icalendar_url}}">ical</a>
+    {% if user.is_authenticated %}
       <span class="hoverHidden">| created by</span> <a class="hoverHidden" href="/wiki/Benutzer:{{ event.created_by }}">{{ event.created_by }}</a>
     {%endif %}
   </p>


### PR DESCRIPTION
iCal links are hidden if one is not logged in, making it hard to quickly add Metalab events to a local iCal account while casually browsing the website.

**Steps to reproduce:**

 - Go to https://metalab.at/calendar/
 - Look for the PyUGAT event for "Thu 21.09.2023 19:30 - 23:00"
 - Have a sudden desire to download/add iCal to my local calendar

**Expected result:**

 - ical link appears, can be clicked, and the ical downloads

**Actual result:**

 - No link appears

**Additional information:**

By inspecting the HTML source / DOM, one can see that the ID is 7012 (from "calendar-view-7012"). Taking an old link (from the pyug.at start page) like https://metalab.at/calendar/event/6621/icalendar/ and replacing 6621 here with 7012 lets me download the iCal file for the new event, so it isn't necessarily an authenticated feature.

**Proposed fix:**

* Instead of hiding "edit", "ical" and "created by" behind a "user is logged in + edit isn't disabled" check, show:
  * "edit" link if user is logged in and edit is not disabled
  * "ical" link unconditionally
  * "created by" info if user is logged in (even if edit is disabled)

**Can of worms:**

I tried to do a minimally invasive change (not changing the order of items as they appear on the website).

One could also reorder it in such a fashion (pseudocode):

```
    "ical"
    if user.is_authenticated:
        if not edit_disabled:
            "| edit"
        "| created by xyz"
```

This way, it would appear as such for non logged in users:

 - [ical](#)

And for logged in users, when edit is disabled:

 - [ical](#) | created by [xyz](#)

And when it can be edited:

 - [ical](#) | [edit](#) | created by [xyz](#)