### PR TITLE
Calendar: Put navigation links into header, center

### DIFF
--- a/cal/views.py
+++ b/cal/views.py
@@ -3,7 +3,7 @@ from itertools import groupby
 import json
 import urllib.parse
 
-from calendar import HTMLCalendar
+from calendar import HTMLCalendar, month_name
 from dateutil import relativedelta
 
 from django.contrib.auth.decorators import login_required
@@ -53,15 +53,24 @@ class EventCalendar(HTMLCalendar):
             return self.day_cell(cssclass, day)
         return self.day_cell('noday', '&nbsp;')
 
-    def formatmonth(self, year, month):
-        self.year, self.month = year, month
+    def formatmonthname(self, theyear, themonth, withyear=True):
+        # Adapted from Python's Lib/calendar.py
 
-        d = date(int(year), int(month), 1)
+        if withyear:
+            s = '%s %s' % (month_name[themonth], theyear)
+        else:
+            s = '%s' % month_name[themonth]
+
+        d = date(int(theyear), int(themonth), 1)
         prev = d - relativedelta.relativedelta(months=1)
         next = d + relativedelta.relativedelta(months=1)
-        
-        head = '<a href="/calendar/%04d/%02d/">&lt;</a> <a href="/calendar/%04d/%02d/">&gt;</a>' % (prev.year, prev.month, next.year, next.month)
-        return head + super().formatmonth(year, month)
+
+        return f'''
+        <tr><th colspan="7" class="{self.cssclass_month_head}">
+            <a href="/calendar/{prev.year:04d}/{prev.month:02d}/">&lt;</a>
+            {s}
+            <a href="/calendar/{next.year:04d}/{next.month:02d}/">&gt;</a>
+        </th></tr>'''
 
     def group_by_day(self, events):
         field = lambda event: event.startDate.day

--- a/cal/views.py
+++ b/cal/views.py
@@ -30,14 +30,18 @@ class EventCalendar(HTMLCalendar):
 
     def formatday(self, day, weekday):
         if day != 0:
-            d = date(self.year, self.month, day)
-            d1 = d + relativedelta.relativedelta(days=1)  # next day
+            # self.year and self.month are set as a side-effect of formatmonth()
+            this_day = date(self.year, self.month, day)
+            next_day = this_day + relativedelta.relativedelta(days=1)
             cssclass = self.cssclasses[weekday]
-            if date.today() == date(self.year, self.month, day):
+            if date.today() == this_day:
                 cssclass += ' today'
                 cssclass += ' filled'
             body = ['<ul class="daily-events">']
-            for event in self.events.exclude(startDate__gt=d1).exclude(endDate__lt=d, endDate__isnull=False).exclude(endDate__isnull=True, startDate__lt=d):
+            for event in (self.events
+                          .exclude(startDate__gt=next_day)
+                          .exclude(endDate__lt=this_day, endDate__isnull=False)
+                          .exclude(endDate__isnull=True, startDate__lt=this_day)):
                 body.append('<li class="event">')
                 if self.admin:
                     body.append(u'<a href="%s" class="edit" title="edit">✏️</a>' % event.get_absolute_url())

--- a/cal/views.py
+++ b/cal/views.py
@@ -53,6 +53,11 @@ class EventCalendar(HTMLCalendar):
             return self.day_cell(cssclass, day)
         return self.day_cell('noday', '&nbsp;')
 
+    def formatmonth(self, year, month):
+        # Remember year and month for use in formatday()
+        self.year, self.month = year, month
+        return super().formatmonth(year, month)
+
     def formatmonthname(self, theyear, themonth, withyear=True):
         # Adapted from Python's Lib/calendar.py
 

--- a/static/stylesheets/cal.css
+++ b/static/stylesheets/cal.css
@@ -80,7 +80,7 @@ table.month th.month {
     font-size: 20pt;
     padding: 4px 0;
     color: #aaa;
-    text-align: right;
+    text-align: center;
 }
 
 table.month td {


### PR DESCRIPTION
The "previous month" and "next month" links are tiny, especially on mobile.

Untested but assumed working, please test before merging (I don't have the web app set up locally atm, the screenshots are just mocked up using "inspect element" in the browser).

This is based on https://github.com/python/cpython/blob/main/Lib/calendar.py#L499 as reference.

# Current layout

![Screenshot 2023-09-13 at 10 31 00](https://github.com/Metalab/mos/assets/135241/416ffb97-8ffc-465e-a1d8-68b8f922095e)

# Proposed change

![Screenshot 2023-09-13 at 10 30 54](https://github.com/Metalab/mos/assets/135241/7c64d43b-0b81-4e15-9c50-87a5a95d5055)
