### PR TITLE
Update Dockerfile (netcat) + add docker-compose instructions

### DIFF
--- a/HACKING_WITH_DOCKER
+++ b/HACKING_WITH_DOCKER
@@ -1,0 +1,11 @@
+Install docker and docker-compose on your host OS (example for Debian/Ubuntu):
+
+    sudo apt install docker.io docker-compose
+
+Then, build and run the Docker image:
+
+    docker-compose -f docker/docker-compose.yml run --service-ports mos
+
+After it is up and running, point your web browser to:
+
+    http://localhost:8020/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /code
 COPY . /code/
 
 RUN apt-get update \
-    && apt-get install -y --force-yes libmariadb-dev libjpeg-dev netcat \
+    && apt-get install -y --force-yes libmariadb-dev libjpeg-dev netcat-traditional \
     && pip3 install --no-cache-dir -vvv -r /code/requirements.txt \
     && pip3 install --no-cache-dir -vvv -Ur /code/requirements-dev.txt
 


### PR DESCRIPTION
Some documentation on how to run it with `docker-compose`. The `netcat` package caused issues when installing:

```
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8906 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6432 B]
Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [62.1 kB]
Fetched 9226 kB in 2s (5277 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47

W: --force-yes is deprecated, use one of the options starting with --allow instead.
E: Package 'netcat' has no installation candidate
```