### PR TITLE
Calendar: Sort events with start date, ascending

### DIFF
--- a/cal/views.py
+++ b/cal/views.py
@@ -97,7 +97,7 @@ class EventCalendar(HTMLCalendar):
 
 def index(request):
     d = date.today() - relativedelta.relativedelta(days=2)
-    cal = EventCalendar(Event.all, request.user.is_authenticated).currentmonth()
+    cal = EventCalendar(Event.all.order_by('startDate'), request.user.is_authenticated).currentmonth()
     date_list = Event.all.all().datetimes('startDate', 'year')
     latest_events = Event.all.filter(startDate__gte=d).order_by('startDate')
 
@@ -116,7 +116,7 @@ def monthly(request, year, month):
 
     e = date(int(year), int(month), 1) + relativedelta.relativedelta(months=1)
     latest_events = Event.all.filter(startDate__gte=s, startDate__lt=e).order_by('startDate')
-    cal = EventCalendar(Event.all, request.user.is_authenticated).formatmonth(int(year), int(month))
+    cal = EventCalendar(Event.all.order_by('startDate'), request.user.is_authenticated).formatmonth(int(year), int(month))
     date_list = Event.all.all().datetimes('startDate', 'year')
 
     return render(request, 'cal/event_archive.html', {


### PR DESCRIPTION
Just noticed this today:

![Screenshot 2023-09-19 at 08 18 34](https://github.com/Metalab/mos/assets/135241/598e75fe-bdca-43e3-bbd6-526d39fcefe2)

(19:00, 18:00, 19:00 -- non-chronological ordering)

In the events list, this problem doesn't exist:

![Screenshot 2023-09-19 at 08 19 34](https://github.com/Metalab/mos/assets/135241/f7fdf8a8-a5d8-4495-9be9-632cab9cf7dc)

The reason for this is that `latest_events` has `.order_by('startDate')`, but the `Event.all` passed into `EventCalendar` doesn't enforce the ordering.

In theory, due to the way `EventCalendar` works, a tighter query (only events with start date / end date overlapping the month to be rendered) could be used, but I opted for the less intrusive solution to not introduce regressions.