### PR TITLE
Calendar: Remove unused `group_by_day()` function

### DIFF
--- a/cal/views.py
+++ b/cal/views.py
@@ -81,12 +81,6 @@ class EventCalendar(HTMLCalendar):
             <a href="/calendar/{next.year:04d}/{next.month:02d}/">&gt;</a>
         </th></tr>'''
 
-    def group_by_day(self, events):
-        field = lambda event: event.startDate.day
-        return dict(
-            [(day, list(items)) for day, items in groupby(events, field)]
-        )
-
     def day_cell(self, cssclass, body):
         return '<td class="%s">%s</td>' % (cssclass, body)
 


### PR DESCRIPTION
I think `group_by_day()` isn't used (anymore?), I checked also [`calendar.py`](https://github.com/python/cpython/blob/main/Lib/calendar.py) in CPython. It could be that some code outside of the `mos` repository uses this function, though.