### PR TITLE
feat(user): add oauth2 provider

### DIFF
--- a/members/urls.py
+++ b/members/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
 
     path('', include('django.contrib.auth.urls')),
 
+    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     re_path(r'^valid_user/?$', members.views.valid_user),
     path('history/', members.views.members_history),
     path('hetti/', members.views.hetti),

--- a/mos/settings/common.py
+++ b/mos/settings/common.py
@@ -121,6 +121,7 @@ INSTALLED_APPS = (
     'announce',
     'core',
     'channels',
+    'oauth2_provider',
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sepaxml
 daphne
 requests
 easy-thumbnails
+django-oauth-toolkit


### PR DESCRIPTION
According to https://django-oauth-toolkit.readthedocs.io/en/latest/getting_started.html this should be all that is needed for an oauth provider. Migrations run through, I can see Oauth settings in the admin, eg. for adding a new oauth client, but I did not test it.