### PR TITLE
fix(iban validator): handle spaces in iban

### DIFF
--- a/members/models.py
+++ b/members/models.py
@@ -132,8 +132,9 @@ def iban_letters2numbers(iban):
         result.append(final_char)
     return "".join(result)
 
-def iban_validate(iban):
+def iban_validate(iban: str) -> None:
     """Validates a given IBAN"""
+    iban = iban.replace(" ","")
     if not iban.isalnum():
         raise ValidationError("IBAN can only contain numbers (0-9) and letters (A-Z)!")
     if len(iban) < 4:


### PR DESCRIPTION
adresses #209 

As far as i can find spaces get stripped when used for the Payment anyways and other than display in the member profile i didn't find other uses for it so adjusting the validator should be fine